### PR TITLE
Syntax update + Installation for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Fluent syntax highlighting for VIM/NeoVIM.
 
 ## Installation
 
-### Using [Vundle][]
+### Using [Vundle]
 
 1. Add `Plugin 'projectfluent/fluent.vim'` to `~/.vimrc`
 2. `:PluginInstall` or `$ vim +PluginInstall +qall`
@@ -30,6 +30,9 @@ git clone --depth=1 https://github.com/projectfluent/fluent.vim.git ~/.vim/bundl
 1. Add `Plug 'projectfluent/fluent.vim'` to `~/.vimrc`
 2. `:PlugInstall` or `$ vim +PlugInstall +qall`
 
+### Using [lazy.nvim]
+1. Add `{ "projectfluent/fluent.vim", ft = "fluent" }` to your list of plugins.
+
 
 ## Status
 
@@ -47,3 +50,4 @@ Find out more about Project Fluent at [projectfluent.org][], including links to 
 [Pathogen]: https://github.com/tpope/vim-pathogen
 [NeoBundle]: https://github.com/Shougo/neobundle.vim
 [vim-plug]: https://github.com/junegunn/vim-plug
+[lazy.nvim]: https://github.com/folke/lazy.nvim/

--- a/syntax/fluent.vim
+++ b/syntax/fluent.vim
@@ -17,7 +17,7 @@ syntax match fluentVariantKey contained "\v\*?\[\s*[a-zA-Z0-9_-]+\s*\]" nextgrou
 syntax match fluentVariable contained "\v\$[a-zA-Z][a-zA-Z0-9_-]*"
 syntax match fluentIdentifierExpression contained "\v\-?[a-zA-Z][a-zA-Z0-9_-]*"
 syntax match fluentIdentifierTerm contained "\v\-[a-zA-Z][a-zA-Z0-9_-]+"
-syntax match fluentFunction contained "\v[A-Z]+"
+syntax match fluentFunction contained "\v[A-Z]+[A-Z0-9-_]+"
 syntax match fluentStringLiteral contained "\v\"[a-z]+\""
 syntax match fluentNumberLiteral contained "\v[0-9]+"
 syntax match fluentVariantSelectorOperator contained "\v\-\>"

--- a/syntax/fluent.vim
+++ b/syntax/fluent.vim
@@ -11,12 +11,15 @@ syntax region fluentPattern contained start="" end="\v^(( )@!|( +[\.\[\*\}])@=)"
 syntax match fluentAttribute "\v\.[a-zA-Z][a-zA-Z0-9-]*" nextgroup=fluentDelimiter
 syntax region fluentPlaceable contained start=+{+ end=+}+ contains=@fluentExpression
 
-syntax cluster fluentExpression contains=fluentFunction,fluentVariantKey,fluentVariable,fluentIdentifierExpression,fluentVariantSelectorOperator
+syntax cluster fluentExpression contains=fluentFunction,fluentVariantKey,fluentVariable,fluentIdentifierExpression,fluentIdentifierTerm,fluentStringLiteral,fluentNumberLiteral,fluentVariantSelectorOperator
 
 syntax match fluentVariantKey contained "\v\*?\[\s*[a-zA-Z0-9_-]+\s*\]" nextgroup=fluentPattern
 syntax match fluentVariable contained "\v\$[a-zA-Z][a-zA-Z0-9_-]*"
 syntax match fluentIdentifierExpression contained "\v\-?[a-zA-Z][a-zA-Z0-9_-]*"
+syntax match fluentIdentifierTerm contained "\v\-[a-zA-Z][a-zA-Z0-9_-]+"
 syntax match fluentFunction contained "\v[A-Z]+"
+syntax match fluentStringLiteral contained "\v\"[a-z]+\""
+syntax match fluentNumberLiteral contained "\v[0-9]+"
 syntax match fluentVariantSelectorOperator contained "\v\-\>"
 
 highlight link fluentComment Comment
@@ -26,9 +29,12 @@ highlight link fluentIdentifier Identifier
 highlight link fluentPattern String
 highlight link fluentAttribute Keyword
 highlight link fluentFunction Function
+highlight link fluentStringLiteral String
+highlight link fluentNumberLiteral Number
 highlight link fluentVariantKey Tag
 highlight link fluentVariable Keyword
 highlight link fluentIdentifierExpression Identifier
+highlight link fluentIdentifierTerm Special
 highlight link fluentDelimiter Operator
 highlight link fluentVariantSelectorOperator Operator
 

--- a/syntax/fluent.vim
+++ b/syntax/fluent.vim
@@ -2,8 +2,9 @@ if exists("b:current_syntax")
     finish
 endif
 
-syntax region fluentComment start="\v^#" end="\v^(#)@!" contains=fluentTitleComment
-syntax region fluentTitleComment start=/\v(^#.*$\n)@<!^(###|##)/ms=e+1 end="$"
+syntax region fluentComment start="\v^#" end="\v^(#)@!" contains=fluentGroupComment,fluentResourceComment
+syntax region fluentGroupComment start=/\v(^##)@<!^## /ms=e+1 end="$"
+syntax region fluentResourceComment start=/\v(^###)@<!^### /ms=e+1 end="$"
 syntax match fluentIdentifier "^\v-?[a-zA-Z][a-zA-Z0-9_-]*" nextgroup=fluentDelimiter
 syntax match fluentDelimiter "\s*=\s*" contained skipnl nextgroup=fluentPattern
 syntax region fluentPattern contained start="" end="\v^(( )@!|( +[\.\[\*\}])@=)" contains=fluentPlaceable
@@ -19,7 +20,8 @@ syntax match fluentFunction contained "\v[A-Z]+"
 syntax match fluentVariantSelectorOperator contained "\v\-\>"
 
 highlight link fluentComment Comment
-highlight link fluentTitleComment Constant
+highlight link fluentGroupComment Constant
+highlight link fluentResourceComment Define
 highlight link fluentIdentifier Identifier
 highlight link fluentPattern String
 highlight link fluentAttribute Keyword

--- a/syntax/fluent.vim
+++ b/syntax/fluent.vim
@@ -3,7 +3,7 @@ if exists("b:current_syntax")
 endif
 
 syntax region fluentComment start="\v^#" end="\v^(#)@!" contains=fluentTitleComment
-syntax region fluentTitleComment start=/\v(^#.*$\n)@<!^##/ms=e+1 end="$"
+syntax region fluentTitleComment start=/\v(^#.*$\n)@<!^(###|##)/ms=e+1 end="$"
 syntax match fluentIdentifier "^\v-?[a-zA-Z][a-zA-Z0-9_-]*" nextgroup=fluentDelimiter
 syntax match fluentDelimiter "\s*=\s*" contained skipnl nextgroup=fluentPattern
 syntax region fluentPattern contained start="" end="\v^(( )@!|( +[\.\[\*\}])@=)" contains=fluentPlaceable


### PR DESCRIPTION
Adds syntax for:
- Resource level and group level comments (and multi-line for them)
- Function parameters
- [Terms](https://projectfluent.org/fluent/guide/terms.html)

And added installation instructions for [lazy.nvim](https://github.com/folke/lazy.nvim/)

I am still not quite 100% sure if the highlight group for the ResourceComment is a good group, but we can change if necessary.

Before and after:
![beforeandafter](https://github.com/user-attachments/assets/96f78d45-1b78-41d1-ba31-40b1278f2fb3)


